### PR TITLE
Fix dependency for Ubuntu > 12.04

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/chroot/extensions/PBuilderWorker.java
+++ b/src/main/java/org/jenkinsci/plugins/chroot/extensions/PBuilderWorker.java
@@ -191,7 +191,7 @@ public final class PBuilderWorker extends ChrootWorker {
     
     public List<String> getDefaultPackages() {
         return new ImmutableList.Builder<String>()
-                .add("python-software-properties")
+                .add("software-properties-common")
                 .add("sudo")
                 .add("wget").build();
     }


### PR DESCRIPTION
Appearently `python-software-properties` has been renamed to `software-properties-common` in Ubuntu. So unless support for Ubuntu 10.04 is a requirement for you I'd recommend switching to `software-properties-common`.
See 
http://packages.ubuntu.com/search?keywords=python-software-properties
and
http://packages.ubuntu.com/search?keywords=software-properties-common
for comparison.

Cheers,
tablet-mode