### PR TITLE
Obtain a reference to AbstractProject in validation.

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/chroot/builders/ChrootBuilder.java
+++ b/src/main/java/org/jenkinsci/plugins/chroot/builders/ChrootBuilder.java
@@ -49,6 +49,7 @@ import org.jenkinsci.plugins.chroot.tools.ChrootToolset;
 import org.jenkinsci.plugins.chroot.util.ChrootUtil;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
+import org.kohsuke.stapler.AncestorInPath;
 
 /**
  *
@@ -215,13 +216,18 @@ public class ChrootBuilder extends Builder implements Serializable {
             return "Chroot Builder";
         }
 
-        public FormValidation doCheckPackagesFile(@QueryParameter String value)
+        public FormValidation doCheckPackagesFile(@AncestorInPath AbstractProject project, @QueryParameter String value)
                 throws IOException, ServletException, InterruptedException {
             List<String> validationList = new LinkedList<String>();
             Boolean warn = false;
             Boolean error = false;
+            FilePath workspace = project.getSomeWorkspace();
             for (String file : ChrootUtil.splitFiles(value)) {
-                FilePath x = new FilePath(new File(file));
+                if (workspace == null) {
+                    // return here => exactly one warning, iff field has a value
+                    return FormValidation.warning("Workspace does not yet exist.");
+                }
+                FilePath x = new FilePath(workspace, file);
                 if (!x.exists()) {
                     warn = true;
                     validationList.add(String.format("File %s does not yet exist.", file));


### PR DESCRIPTION
This enables us to look for the file(s) in "some workspace" instead of "somewhere".

Fixes #10.