### PR TITLE
Fixed double execution of ChrootWorker.setUp()

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/chroot/tools/ChrootToolset.java
+++ b/src/main/java/org/jenkinsci/plugins/chroot/tools/ChrootToolset.java
@@ -92,7 +92,7 @@ public final class ChrootToolset extends ToolInstallation implements Environment
         if (Strings.isNullOrEmpty(home)) {
             throw new IOException("The node " + node.getDisplayName() + " is not correctly setup up for " + this.getToolName());
         }
-        return new ChrootToolset(getName(), translateFor(node, listener), getToolName(), getProperties().toList());
+        return new ChrootToolset(getName(), home, getToolName(), getProperties().toList());
     }
 
     public static ChrootToolset getInstallationByName(String name) {


### PR DESCRIPTION
This fixes a bug which would result in ChrootWorker/PBuilderWorker.setUp() to be called twice during installation times.