### PR TITLE
Bugfix for md5 sums with trailing whitespaces

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/chroot/util/ChrootUtil.java
+++ b/src/main/java/org/jenkinsci/plugins/chroot/util/ChrootUtil.java
@@ -66,7 +66,7 @@ public class ChrootUtil {
         if (!md5.exists()) {
             return null;
         }
-        return md5.readToString();
+        return md5.readToString().trim();
     }
 
     public static FilePath getDigestFile(FilePath file) {


### PR DESCRIPTION
Add an additional trim() call on the md5 sum from the Digest file, some systems write md5 sums with trailing whitespace e.g: newline